### PR TITLE
テーブルからレコードを全件取得するAPIを実装後、クエリ文字列を指定して検索するAPIも実装

### DIFF
--- a/src/main/java/com/example/nameservice/Name.java
+++ b/src/main/java/com/example/nameservice/Name.java
@@ -1,0 +1,20 @@
+package com.example.nameservice;
+
+public class Name {
+
+    private int id;
+    private String name;
+
+    public Name(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public  String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/nameservice/NameController.java
+++ b/src/main/java/com/example/nameservice/NameController.java
@@ -1,5 +1,8 @@
 package com.example.nameservice;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,7 +19,16 @@ public class NameController {
     }
 
     @GetMapping("/names")
-    public List<Name> findByNames(@RequestParam String startsWith) {
-        return nameMapper.findByNameStartingWith(startsWith);
+    public ResponseEntity<List<Name>> findByNames(@RequestParam String startsWith) {
+        if (StringUtils.isEmpty(startsWith)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+
+        List<Name> names = nameMapper.findByNameStartingWith(startsWith);
+        if (names.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+
+        return ResponseEntity.ok(names);
     }
 }

--- a/src/main/java/com/example/nameservice/NameController.java
+++ b/src/main/java/com/example/nameservice/NameController.java
@@ -26,7 +26,7 @@ public class NameController {
 
         List<Name> names = nameMapper.findByNameStartingWith(startsWith);
         if (names.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+            return ResponseEntity.ok(names);
         }
 
         return ResponseEntity.ok(names);

--- a/src/main/java/com/example/nameservice/NameController.java
+++ b/src/main/java/com/example/nameservice/NameController.java
@@ -1,0 +1,22 @@
+package com.example.nameservice;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class NameController {
+
+    private NameMapper nameMapper;
+
+    public  NameController(NameMapper nameMapper) {
+        this.nameMapper = nameMapper;
+    }
+
+    @GetMapping("/names")
+    public List<Name> findByNames(@RequestParam String startsWith) {
+        return nameMapper.findByNameStartingWith(startsWith);
+    }
+}

--- a/src/main/java/com/example/nameservice/NameMapper.java
+++ b/src/main/java/com/example/nameservice/NameMapper.java
@@ -8,6 +8,6 @@ import java.util.List;
 @Mapper
 public interface NameMapper {
 
-    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
+    @Select("SELECT * FROM names WHERE name LIKE BINARY CONCAT(#{prefix}, '%')")
     List<Name> findByNameStartingWith(String prefix);
 }

--- a/src/main/java/com/example/nameservice/NameMapper.java
+++ b/src/main/java/com/example/nameservice/NameMapper.java
@@ -8,9 +8,6 @@ import java.util.List;
 @Mapper
 public interface NameMapper {
 
-    @Select("SELECT * FROM names")
-    List<Name> findAll();
-
     @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
     List<Name> findByNameStartingWith(String prefix);
 }

--- a/src/main/java/com/example/nameservice/NameMapper.java
+++ b/src/main/java/com/example/nameservice/NameMapper.java
@@ -1,0 +1,16 @@
+package com.example.nameservice;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface NameMapper {
+
+    @Select("SELECT * FROM names")
+    List<Name> findAll();
+
+    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
+    List<Name> findByNameStartingWith(String prefix);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=nameservice
+spring.datasource.url=jdbc:mysql://localhost:3307/name_database
+spring.datasource.username=user
+spring.datasource.password=password


### PR DESCRIPTION
# 概要

掲題の通りです。
名前を２つ追加し、「p」から始まる名前を検索しました。

# 下記ターミナルで名前を２つ追加した操作内容です。

<img width="911" alt="Screenshot 2024-04-21 at 14 38 21" src="https://github.com/Chiiiho/Java-8-nameservice/assets/163135461/0d463934-43a4-4892-aa0f-42a962d27704">
<img width="761" alt="Screenshot 2024-04-21 at 14 40 06" src="https://github.com/Chiiiho/Java-8-nameservice/assets/163135461/19eaf3bf-0354-45a1-a996-0336b2f1df41">
<img width="634" alt="Screenshot 2024-04-21 at 14 46 02" src="https://github.com/Chiiiho/Java-8-nameservice/assets/163135461/3fd6f3ad-c4ac-4e70-88a8-1d66e48b7d57">

# 動作確認
Postman を使いました。
下記確認済みです。

- レスポンスボディが p で始まる名前、 Phil と Pearl であること
- レスポンスのステータスコードが 200 (OK 成功) であること
- json形式であること


<img width="1015" alt="Screenshot 202-04-21 at 14 36 13" src="https://github.com/Chiiiho/Java-8-nameservice/assets/163135461/f8871391-023e-45fa-b218-482cd6916de8">
<img width="1010" alt="Screenshot 2024-04-21 at 14 36 27" src="https://github.com/Chiiiho/Java-8-nameservice/assets/163135461/4b2bb2ea-89ba-4409-b676-49d4d3162dd8">



